### PR TITLE
Edits to the licensing section

### DIFF
--- a/data_sharing_ms.md
+++ b/data_sharing_ms.md
@@ -437,17 +437,17 @@ These are not repositories exclusively used by members of institutions or reposi
 10. Use an established and liberal license 
 -----------------------------------------
 
-Responsible data sharing requires clear communication of the rights and responsibilities of data providers, repositories, and data users.
-This means clarifying rights retained or waived by the provider, unambiguous terms under which data can be used and redistributed, and providing means for accountability under conditions that attract [copyright](http://www.copyright.gov/circs/circ1.pdf).
-Increasingly, this means explicitly licensing one's data, i.e. legally waive or retain certain rights and restrictions to users.
+Including an explicit license with your data is the best way to let others know exactly what they can and cannot do with the data you shared.
+Other scientists are more likely to use your data if it is clear exactly what they can do with it.
+We recommend using well established licenses (e.g., [Creative Commons licenses](http://creativecommons.org/licenses/)) in order to clearly communicate the rights and responsibilities of both the people providing the data and the people using it.
+We also recommend using the most open license possible (CC0; http://creativecommons.org/publicdomain/zero/1.0/), because even minor restrictions on data use can have unintended consequences for the reuse of the data [@schofield2009].
 
-Most, if not all, repositories include provisions for terms of use.
-Currently, few repositories include provisions for explicit licensing (Table section 9).
-Some that do, require users to use one or more established [Creative Commons licenses](http://creativecommons.org/licenses/) (e.g. [Dryad](http://blog.datadryad.org/2011/10/05/why-does-dryad-use-cc0/), Figshare).
-Others capable of hosting data and computing code allow users to include Creative Commons and [Open Source licenses](http://opensource.org/licenses) (e.g. Github).
+Most repositories have either a required data license or the option to choose among a set of data licences (Table section 9).
+By far the most common are Creative Commons licenses(http://creativecommons.org/licenses/).
+It is increasingly thought that CC0, which places no restrictions on the use of the data, is the best license for sharing data (e.g. [@schofield2009], http://blog.datadryad.org/2011/10/05/why-does-dryad-use-cc0/).
+Other forms of Creative Commons licenses that require attribution, non-commercial use, and equivalent licensing of derivative works are also common.
 Data sharers should familiarize themselves with the policies and licensing options of a particular repository, as well as forms of data that attract copyright.
 More can be learned about copyright by visiting The [University of Michigan website](http://www.lib.umich.edu/copyright/facts-and-data), the website of the [Australian National Data Service](http://www.ands.org.au/guides/copyright-and-data-awareness.html), and the [Digital Curation Center](http://www.dcc.ac.uk/resources/how-guides/license-research-data#x1-140007).
-More can be learned about licensing by visiting websites of the [Creative Commons](http://wiki.creativecommons.org/FAQ#Can_I_use_a_Creative_Commons_license_for_software.3F) and [Open Source Initiative](http://opensource.org/faq).
 
 
 Concluding remarks

--- a/data_sharing_refs.bib
+++ b/data_sharing_refs.bib
@@ -99,6 +99,17 @@
   publisher={American Association for the Advancement of Science, 1200 New York Avenue, NW Washington DC 20005 USA}
 }
 
+@article{schofield2009,
+  title={Post-publication sharing of data and tools},
+  author={Schofield, Paul N and Bubela, Tania and Weaver, Thomas and Portilla, Lili and Brown, Stephen D and Hancock, John M and Einhorn, David and Tocchini-Valentini, Glauco and de Angelis, Martin Hrabe and Rosenthal, Nadia},
+  journal={Nature},
+  volume={461},
+  number={7261},
+  pages={171--173},
+  year={2009},
+  publisher={Nature Publishing Group}
+}
+
 @article{whitlock2010,
   title={Data archiving},
   author={Whitlock, Michael C and McPeek, Mark A and Rausher, Mark D and Rieseberg, Loren and Moore, Allen J},


### PR DESCRIPTION
1. General de-lawyerizing
2. Reducing copyright discussion since the data being shared by our target audience is unlikely to be copyrightable.
3. More emphasis on CC licenses and an explicit recommendation of CC0
